### PR TITLE
[DEPRECATION WARNING]: evaluating cmake_modify_path as a bare variable.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,7 +60,7 @@
     state: touch
 
 - name: Add CMake to everyone's PATH
-  when: cmake_modify_path
+  when: cmake_modify_path|bool
   become: true
   blockinfile:
     state: present


### PR DESCRIPTION
This behaviour will go away and you might need to add |bool to the
expression in the future. Also see CONDITIONAL_BARE_VARS configuration
toggle... This feature will be removed in version 2.12.
Deprecation warnings can be disabled by setting
    deprecation_warnings=False
in ansible.cfg.